### PR TITLE
Moved from deprecated python setup.py install to pip install .

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A GUI client for connecting to the SurfShark VPN.
 ![surfshark-vpn-gui](https://user-images.githubusercontent.com/554899/79762280-8f876b00-82f0-11ea-9d4a-e050498f8bc7.png)
 
 ### About
+
 There is currently no official GUI client for the SurfShark VPN on Linux, so this is to fill the need! This client uses OpenVPN to setup the connection, so the surfshark-vpn package is not required.
 
 ### Instructions
@@ -15,15 +16,15 @@ There is currently no official GUI client for the SurfShark VPN on Linux, so thi
   ```
 1. Clone the surfshark-vpn-gui repo:
   ```
-   git clone --depth 1 https://github.com/jakeday/surfshark-vpn-gui.git ~/surfshark-vpn-gui
+   git clone --depth 1 https://github.com/jakeday/surfshark-vpn-gui.git
   ```
 2. Change directory to surfshark-vpn-gui repo:
   ```
-   cd ~/surfshark-vpn-gui
+   cd surfshark-vpn-gui/
   ```
 3. Install the app:
   ```
-   sudo python3 setup.py install
+   pip install .
   ```
 4. With the client open, be sure to enter your SurfShark credentials by clicking the Enter Credentials button.
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-import os
 import setuptools
 import setuptools.command.build_py
 
@@ -17,12 +16,12 @@ setuptools.setup(
         ('/usr/share/applications', ['surfsharkgui/assets/surfsharkgui.desktop'])
     ],
     package_data={
-        "": ["assets/*"]
+        '': ['assets/*']
     },
     packages=setuptools.find_packages(),
     entry_points={
         'console_scripts': [
-            'surfsharkvpngui=surfsharkgui',
+            'surfsharkvpngui=surfsharkgui:main',
         ],
     },
 )

--- a/surfsharkgui/__init__.py
+++ b/surfsharkgui/__init__.py
@@ -207,5 +207,9 @@ class MyApp(wx.App):
             with zipfile.ZipFile(configurations_path, 'r') as zip_conf:
                 zip_conf.extractall(locations_path)
 
-app = MyApp()
-app.MainLoop()
+def main():
+    app = MyApp()
+    app.MainLoop()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Hello :)

An other PR is here!

As `python setup.py install` is deprecated, I switched to `pip install .` whitch has several improvements.

- It fixes an issue where `python setup.py install` should run as root (sudo was needed before)
- This change is more clean to import the module when running __init__.py
- Fixes a bug where running surfsharkvpngui and close the software throws an error in the shell

I hope you will like this change!
